### PR TITLE
UI and markup improvements

### DIFF
--- a/views/admin/css/editorial.css
+++ b/views/admin/css/editorial.css
@@ -1,6 +1,7 @@
 
 .editorial-block-response-container {
     clear: both;
+    margin-bottom: 10px;
 }
 
 .editorial-block-response,
@@ -26,6 +27,10 @@
 
 .editorial-block-response .mceEditor {
     display: block;
+    margin-top: 10px;
+}
+
+.response-replies {
     margin-top: 10px;
 }
 
@@ -88,4 +93,53 @@
 
 .send-emails > div:not(:last-child) {
     margin: 0 0 20px;
+}
+
+a.collapse-response:visited,
+a.expand-response:visited {
+    color: #C76941;
+}
+
+.response-text > *:last-child {
+    margin-bottom: 0;
+}
+
+.original-response.preview {
+    overflow: hidden;
+    position: relative;
+}
+
+.preview .response-text {
+    max-height: 15em;
+    overflow: hidden;
+    position: relative;
+}
+
+.preview .response-text:after {
+    content: "";
+    height: 3em;
+    background-image: linear-gradient(rgba(0,0,0,0), #fbfbf9 100%);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 10.5em;
+}
+
+.preview .response-text ~ .collapse-response {
+    display: none;
+}
+
+.preview .response-text ~ .expand-response {
+    position: absolute;
+    top: 13.5em;
+    left: 0;
+    right: 0;
+    background-color: #fbfbf9;
+    line-height: 1.5em;
+    height: 1.5em;
+    padding-top: .25em;
+}
+
+.full .response-text {
+    margin-bottom: 20px;
 }

--- a/views/admin/css/editorial.css
+++ b/views/admin/css/editorial.css
@@ -1,15 +1,32 @@
 
 .editorial-block-response-container {
-    background-color: white;
-    border: 1px solid grey;
-    margin: 5px;
     clear: both;
-    min-height: 120px;
 }
 
-.editorial-block-response {
+.editorial-block-response,
+.cancel-response-edit {
     display: none;
     clear: left;
+}
+
+.edit-response,
+.cancel-response-edit {
+    float: right;
+}
+
+.original-label,
+.original .edit-response,
+.original .cancel-response-edit {
+    color: #d7daa0;
+}
+
+.original-label:before {
+    content: "| ";
+}
+
+.editorial-block-response .mceEditor {
+    display: block;
+    margin-top: 10px;
 }
 
 .editorial-block-response.child {
@@ -20,21 +37,41 @@
 }
 
 .editorial-block-response-info {
-    float: left;
-    width: 100px;
-    margin: 3px;
+    background-color: #D6D5C2;
+    padding: 5px;
+    line-height: 30px;
+}
+
+.original .editorial-block-response-info {
+    background-color: #7C7E5D;
+    color: #fff;
+}
+
+.editorial-block-response-info img {
+    height: 30px;
+    width: auto;
+    display: inline-block;
+    margin-right: 10px;
+    vertical-align: top;
+}
+
+.editorial-block-response-info .username {
+    vertical-align: top;
+    font-weight: bold;
 }
 
 .editorial-block-response-new {
-    margin-left: 25px;
     clear: both;
 }
 
 .editorial-block.reply {
     display: none;
+    margin-bottom: 10px;
 }
 
 .editorial-block.reply-button {
+    border-top: 1px solid #D6D5C2;
+    padding-top: 9px;
     cursor: pointer;
 }
 
@@ -43,6 +80,13 @@
     float: right;
 }
 
-.send-emails div {
-    margin: 10px;
+.editorial.layout-options select,
+.editorial.layout-options .mceEditor {
+    margin-top: 5px;
+    width: 100%;
+    display: block;
+}
+
+.send-emails > div:not(:last-child) {
+    margin: 0 0 20px;
 }

--- a/views/admin/css/editorial.css
+++ b/views/admin/css/editorial.css
@@ -29,11 +29,10 @@
     margin-top: 10px;
 }
 
-.editorial-block-response.child {
-    display:block;
-    margin: 5px 0 0 10px;
-    padding: 5px;
-    border: 1px solid grey;
+.response-replies .child {
+    padding-left: 10px;
+    border-left: 5px solid #D6D5C2;
+    margin-bottom: 10px;
 }
 
 .editorial-block-response-info {

--- a/views/admin/javascripts/editorial.js
+++ b/views/admin/javascripts/editorial.js
@@ -13,11 +13,19 @@
                 deleteButton.remove();
             }
         });
-        
+
+        $('#exhibit-page-form').on('click', '.edit-response,.cancel-response-edit', function(e) {
+            e.preventDefault();
+            $('.edit-response,.cancel-response-edit').toggle();
+            var currentResponse = $(this).parents('.editorial-block-response-container');
+            currentResponse.find('.original-response').toggle();
+            currentResponse.find('.editorial-block-response').toggle();
+        });
+
         $('.editorial-block.reply-button').click(function() {
             $(this).siblings('.reply').toggle();
         });
-        
+
         $('#exhibit-page-form').on('change', '.users-select select', function() {
             var target = $(this);
             var emailSelect = target.parents('.layout-options').find('.email-select');
@@ -26,7 +34,7 @@
                     $(this).remove();
                 }
             });
-            
+
             var selectedUsers = target.find('option:selected');
             selectedUsers.each(function() {
                 var userOption = $(this).clone();
@@ -34,7 +42,7 @@
             });
             emailSelect.attr('size', selectedUsers.length + 2);
         });
-        
+
         $('#exhibit-page-form').on('click', '.email-checkbox', function() {
             var emailSelect = $(this).parents('.layout-options').find('.email-select');
             if (this.checked) {
@@ -43,7 +51,7 @@
                 emailSelect.find('option').prop('selected', false);
             }
         });
-        
+
         $('#exhibit-page-form').on('change', '.email-select', function() {
             var emailCheckbox = $(this).parents('.layout-options').find('.email-checkbox');
             var hasSelected = false;

--- a/views/admin/javascripts/editorial.js
+++ b/views/admin/javascripts/editorial.js
@@ -22,6 +22,14 @@
             currentResponse.find('.editorial-block-response').toggle();
         });
 
+        $('#exhibit-page-form').on('click', '.expand-response,.collapse-response', function(e) {
+            e.preventDefault();
+            var expandCollapse = $(this);
+            expandCollapse.toggle();
+            expandCollapse.siblings('.expand-response,.collapse-response').toggle();
+            expandCollapse.parents('.original-response').toggleClass('preview').toggleClass('full');
+        });
+
         $('.editorial-block.reply-button').click(function() {
             $(this).siblings('.reply').toggle();
         });

--- a/views/admin/javascripts/editorial.js
+++ b/views/admin/javascripts/editorial.js
@@ -16,8 +16,8 @@
 
         $('#exhibit-page-form').on('click', '.edit-response,.cancel-response-edit', function(e) {
             e.preventDefault();
-            $('.edit-response,.cancel-response-edit').toggle();
-            var currentResponse = $(this).parents('.editorial-block-response-container');
+            var currentResponse = $(this).parents('.editorial-block-response-container').first();
+            currentResponse.find('.edit-response,.cancel-response-edit').toggle();
             currentResponse.find('.original-response').toggle();
             currentResponse.find('.editorial-block-response').toggle();
         });

--- a/views/shared/exhibit_layouts/editorial-block/form.php
+++ b/views/shared/exhibit_layouts/editorial-block/form.php
@@ -30,30 +30,104 @@ if ($block->exists()) {
 <div class="block-text editorial no-access">
 <?php endif; ?>
 
-
-
-    <h4><?php echo __('Comment'); ?></h4>
-    
-    
-    <div class='editorial-block-response-info'>
-    <?php
-        $hash = md5(strtolower(trim($blockOwner->email)));
-        $url = "//www.gravatar.com/avatar/$hash";
-    ?>
-        <img class='gravatar' src='<?php echo $url; ?>' />
-        <div><?php echo $blockOwner->username; ?></div>
+    <div class='editorial-block-response-container original'>
+        <div class='editorial-block-response-info'>
+        <?php
+            $hash = md5(strtolower(trim($blockOwner->email)));
+            $url = "//www.gravatar.com/avatar/$hash";
+        ?>
+            <img class='gravatar' src='<?php echo $url; ?>' />
+            <span class="username"><?php echo $blockOwner->username; ?></span>
+            <span class="original-label">Original response</span>
+            <?php if ($changeAllowed): ?>
+            <a href="#" class="edit-response">(Edit)</a>
+            <a href="#" class="cancel-response-edit">(Cancel)</a>
+            <?php endif; ?>
+        </div>
+        <?php if ($changeAllowed): ?>
+        <div class="editorial-block-response">
+        <?php echo $this->exhibitFormText($block); ?>
+        </div>
+        <?php endif; ?>
+        <div class="original-response">
+            <?php echo $block->text; ?>
+            <input type='hidden' name='<?php echo $formStem; ?>[text]' value='<?php echo $block->text; ?>' />
+        </div>
     </div>
-    <?php if ($changeAllowed): ?>
-    <?php echo $this->exhibitFormText($block); ?>
-    <?php else: ?>
-    <div>
-    <?php echo $block->text; ?>
-    <input type='hidden' name='<?php echo $formStem; ?>[text]' value='<?php echo $block->text; ?>' />
-    </div>
-    <?php endif; ?>
-    
+
     <?php if ($block->exists()): ?>
-    <?php $topLevelResponses = get_db()->getTable('EditorialBlockResponse')->findResponsesForBlock($block); ?>
+        <?php $topLevelResponses = get_db()->getTable('EditorialBlockResponse')->findResponsesForBlock($block); ?>
+        <div class='editorial-block-responses'>
+            <?php if (count($topLevelResponses) != 0): ?>
+            <h5><?php __('Conversation'); ?></h5>
+            <?php endif; ?>
+            <?php foreach ($topLevelResponses as $response): ?>
+            <div class='editorial-block-response-container'>
+                <div class='editorial-block-response-info'>
+                <?php
+                    $owner = $response->getOwner();
+                    $hash = md5(strtolower(trim($owner->email)));
+                    $url = "//www.gravatar.com/avatar/$hash";
+                ?>
+                    <img class='gravatar' src='<?php echo $url; ?>' />
+                    <span class="username"><?php echo $owner->username; ?></span>
+                    <a href="#" class="edit-response">(Edit)</a>
+                    <a href="#" class="cancel-response-edit">(Cancel)</a>
+                </div>
+                <div>
+                    <div class='editorial-block-response'>
+                        <?php
+                        if (EditorialPlugin::userHasAccess($response)) {
+                            echo $this->formTextarea($block->getFormStem()."[options][edited_responses][{$response->id}]",
+                                                    $response->text, array('rows' => 8));
+                        } else {
+                            echo $response->text;
+                        }
+                        ?>
+                        <?php
+                            $childResponses = $response->getChildResponses();
+                            foreach ($childResponses as $childResponse) :
+                        ?>
+                        <div class='editorial-block-response-container child'>
+                            <div class='editorial-block-response-info'>
+                            <?php
+                                $owner = $childResponse->getOwner();
+                                $hash = md5(strtolower(trim($owner->email)));
+                                $url = "//www.gravatar.com/avatar/$hash";
+                            ?>
+                                <img class='gravatar' src='<?php echo $url; ?>' />
+                                <div><?php echo $owner->username; ?></div>
+                            </div>
+                            <div>
+                                <?php echo snippet($childResponse->text, 0, 100); ?>
+                            </div>
+                            <div>
+                            <?php
+                            if (EditorialPlugin::userHasAccess($childResponse)) {
+                                echo $this->formTextarea($block->getFormStem()."[options][edited_responses][{$childResponse->id}]",
+                                                        $childResponse->text, array('rows' => 8));
+                            } else {
+                                echo $childResponse->text;
+                            }
+                            ?>
+                            </div>
+                        </div>
+                        <?php endforeach; ?>
+                    </div>
+                    <div class="original-response"><?php echo $response->text; ?></div>
+                    <div>
+                        <p class='editorial-block reply-button'>Reply</p>
+                        <div class='editorial-block reply'>
+                        <?php
+                        echo $this->formTextarea($block->getFormStem()."[options][child_responses][{$response->id}]",
+                                '', array('rows' => 8));
+                        ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
         <div class='editorial-block-response-new'>
             <?php
 
@@ -65,101 +139,24 @@ if ($block->exists()) {
                     );
             ?>
         </div>
-    <?php
-        // block options are all reset from the data in the form,
-        // so spoof in the existing response_ids data
-        foreach ($options['response_ids'] as $responseId):
-    ?>
-    <input type='hidden' name='<?php echo $formStem.'[options][response_ids][]'; ?>' value='<?php echo $responseId; ?>' />
-    
-    <?php endforeach; ?>
-    
-    <div class='editorial-block-responses'>
-        <?php if (count($topLevelResponses) != 0): ?>
-        <h5><?php __('Conversation'); ?></h5>
-        <?php endif; ?>
-        <?php foreach ($topLevelResponses as $response): ?>
+        <?php
+            // block options are all reset from the data in the form,
+            // so spoof in the existing response_ids data
+            foreach ($options['response_ids'] as $responseId):
+        ?>
+        <input type='hidden' name='<?php echo $formStem.'[options][response_ids][]'; ?>' value='<?php echo $responseId; ?>' />
 
-        <div class='editorial-block-response-container'>
-            <div>
-                <div class="drawer closed" role="button" title="<?php echo __('Expand/Collapse'); ?>"></div>
-
-                <div class='editorial-block-response-info'>
-                <?php
-                    $owner = $response->getOwner();
-                    $hash = md5(strtolower(trim($owner->email)));
-                    $url = "//www.gravatar.com/avatar/$hash";
-                ?>
-                    <img class='gravatar' src='<?php echo $url; ?>' />
-                    <div><?php echo $owner->username; ?></div>
-                </div>
-                <div>
-                    <?php echo snippet($response->text, 0, 100); ?>
-                </div>
-            </div>
-            <div class='editorial-block-response'>
-            <?php 
-if (EditorialPlugin::userHasAccess($response)) {
-    echo $this->formTextarea($block->getFormStem()."[options][edited_responses][{$response->id}]",
-                            $response->text, array('rows' => 8));
-} else {
-    echo $response->text;
-}
-            ?>
-                <?php $childResponses = $response->getChildResponses();
-                    foreach ($childResponses as $childResponse) :
-                ?>
-                <div class='editorial-block-response-container child'>
-                    <div class='editorial-block-response-info'>
-                    <?php
-                        $owner = $childResponse->getOwner();
-                        $hash = md5(strtolower(trim($owner->email)));
-                        $url = "//www.gravatar.com/avatar/$hash";
-                    ?>
-                        <img class='gravatar' src='<?php echo $url; ?>' />
-                        <div><?php echo $owner->username; ?></div>
-                    </div>
-                    <div>
-                        <?php echo snippet($childResponse->text, 0, 100); ?>
-                    </div>
-                    <div>
-            <?php
-if (EditorialPlugin::userHasAccess($childResponse)) {
-    echo $this->formTextarea($block->getFormStem()."[options][edited_responses][{$childResponse->id}]",
-                            $childResponse->text, array('rows' => 8));
-} else {
-    echo $childResponse->text;
-}
-            ?>
-                    </div>
-                </div>
-                <?php endforeach; ?>
-
-                <div>
-                    <p class='editorial-block reply-button'>Reply</p>
-                    <div class='editorial-block reply'>
-                    <?php
-                    echo $this->formTextarea($block->getFormStem()."[options][child_responses][{$response->id}]",
-                            '', array('rows' => 8));
-                    ?>
-                    </div>
-                </div>
-            </div>
-
-        </div>
         <?php endforeach; ?>
 
-
-    </div>
     <?php endif; ?>
 </div>
 
-<div class='layout-options'>
+<div class='editorial layout-options'>
     <div class="block-header">
         <h4><?php echo __('Options'); ?></h4>
         <div class="drawer"></div>
     </div>
-    
+
     <?php if ($block->exists()): ?>
     <input type='hidden' name='<?php echo $formStem; ?>[options][old_id]' value='<?php echo $block->id; ?>' />
     <?php endif; ?>
@@ -215,7 +212,7 @@ if (EditorialPlugin::userHasAccess($childResponse)) {
         </div>
     </div>
     <div class='users-select'>
-        <?php 
+        <?php
             if ($changeAllowed) {
                 unset($usersForSelect[$blockOwner->id]);
                 unset($usersForSelect[$currentUser->id]);

--- a/views/shared/exhibit_layouts/editorial-block/form.php
+++ b/views/shared/exhibit_layouts/editorial-block/form.php
@@ -30,22 +30,22 @@ if ($block->exists()) {
 <div class="block-text editorial no-access">
 <?php endif; ?>
 
-    <div class='editorial-block-response-container original'>
-    <?php
-        $hiddenInput = "<input type='hidden' name='" . $formStem . "[text]' value='" . $block->text . "' />";
-        echo $this->partial('single-response.php', array(
-                'original' => true,
-                'originalResponse' => $block->text,
-                'owner' => $blockOwner,
-                'changeAllowed' => $changeAllowed,
-                'editableResponse' => $this->exhibitFormText($block),
-                'hiddenInput' => $hiddenInput
-            )
-        );
-    ?>
-    </div>
 
     <?php if ($block->exists()): ?>
+        <div class='editorial-block-response-container original'>
+        <?php
+            $hiddenInput = "<input type='hidden' name='" . $formStem . "[text]' value='" . $block->text . "' />";
+            echo $this->partial('single-response.php', array(
+                    'original' => true,
+                    'originalResponse' => $block->text,
+                    'owner' => $blockOwner,
+                    'changeAllowed' => $changeAllowed,
+                    'editableResponse' => $this->exhibitFormText($block),
+                    'hiddenInput' => $hiddenInput
+                )
+            );
+        ?>
+        </div>
         <?php $topLevelResponses = get_db()->getTable('EditorialBlockResponse')->findResponsesForBlock($block); ?>
         <div class='editorial-block-responses'>
             <?php foreach ($topLevelResponses as $response): ?>
@@ -109,7 +109,19 @@ if ($block->exists()) {
         <input type='hidden' name='<?php echo $formStem.'[options][response_ids][]'; ?>' value='<?php echo $responseId; ?>' />
 
         <?php endforeach; ?>
-
+    <?php else: ?>
+        <h4>Start a conversation</h4>
+        <div class='editorial-block-response-info'>
+        <?php
+            $hash = md5(strtolower(trim($blockOwner->email)));
+            $url = "//www.gravatar.com/avatar/$hash";
+        ?>
+            <img class='gravatar' src='<?php echo $url; ?>' />
+            <span class="username"><?php echo $blockOwner->username; ?></span>
+        </div>
+        <?php if ($changeAllowed): ?>
+            <?php echo $this->exhibitFormText($block); ?>
+        <?php endif; ?>
     <?php endif; ?>
 </div>
 

--- a/views/shared/single-response.php
+++ b/views/shared/single-response.php
@@ -1,0 +1,26 @@
+<div class='editorial-block-response-info'>
+<?php
+    $hash = md5(strtolower(trim($owner->email)));
+    $url = "//www.gravatar.com/avatar/$hash";
+?>
+    <img class='gravatar' src='<?php echo $url; ?>' />
+    <span class="username"><?php echo $owner->username; ?></span>
+    <?php if ($original): ?>
+    <span class="original-label">Original response</span>
+    <?php endif; ?>
+    <?php if ($changeAllowed): ?>
+    <a href="#" class="edit-response">(Edit)</a>
+    <a href="#" class="cancel-response-edit">(Cancel)</a>
+    <?php endif; ?>
+</div>
+<?php if ($changeAllowed): ?>
+<div class="editorial-block-response">
+    <?php echo $editableResponse; ?>
+</div>
+<?php endif; ?>
+<div class="original-response">
+    <?php echo $originalResponse; ?>
+    <?php if ($hiddenInput): ?>
+        <?php echo $hiddenInput; ?>
+    <?php endif; ?>
+</div>

--- a/views/shared/single-response.php
+++ b/views/shared/single-response.php
@@ -5,7 +5,7 @@
 ?>
     <img class='gravatar' src='<?php echo $url; ?>' />
     <span class="username"><?php echo $owner->username; ?></span>
-    <?php if ($original): ?>
+    <?php if (isset($original)): ?>
     <span class="original-label">Original response</span>
     <?php endif; ?>
     <?php if ($changeAllowed): ?>
@@ -20,7 +20,7 @@
 <?php endif; ?>
 <div class="original-response">
     <?php echo $originalResponse; ?>
-    <?php if ($hiddenInput): ?>
+    <?php if (isset($hiddenInput)): ?>
         <?php echo $hiddenInput; ?>
     <?php endif; ?>
 </div>

--- a/views/shared/single-response.php
+++ b/views/shared/single-response.php
@@ -18,8 +18,10 @@
     <?php echo $editableResponse; ?>
 </div>
 <?php endif; ?>
-<div class="original-response">
-    <?php echo $originalResponse; ?>
+<div class="original-response preview">
+    <div class="response-text"><?php echo $originalResponse; ?></div>
+    <a href="#" class="expand-response">Read more&hellip;</a>
+    <a href="#" class="collapse-response">Collapse</a>
     <?php if (isset($hiddenInput)): ?>
         <?php echo $hiddenInput; ?>
     <?php endif; ?>


### PR DESCRIPTION
**UI**
- To save vertical space, the response information has been condensed into a horizontal header that includes a smaller avatar inline with the username and an edit toggle if the user has edit privileges.
- The input to leave a new comment on a block appears at the bottom of a conversation.
- The expand/collapse is now an edit/cancel toggle to provide better clarity.
- Make exhibit block inputs full width where applicable.

**Markup**
- There is now a `single-response.php` partial. It was difficult and tedious to apply markup changes across each level of commenting, so I think this improves the legibility.
